### PR TITLE
 Fixes /posts/:id DELETE endpoint to delete all entries in all tables referencing the post

### DIFF
--- a/API/posts/posts-model.js
+++ b/API/posts/posts-model.js
@@ -108,6 +108,21 @@ function removePost(id) {
                 .where({post_id: id})
                 .del()
                 .transacting(trx);
+            // Delete the favorites for the specified post
+            await db("user_favorites")
+                .where({post_id: id})
+                .del()
+                .transacting(trx);
+            // Delete the reviews for the specified post
+            await db("user_post_reviews")
+                .where({post_id: id})
+                .del()
+                .transacting(trx);
+            // Delete the comments for the specified post
+            await db("user_post_comments")
+                .where({post_id: id})
+                .del()
+                .transacting(trx);
             // Delete the specified post itself
             const deleted = await db("posts")
                 .where({id})


### PR DESCRIPTION
# Description

 Fixes /posts/:id DELETE endpoint to delete all entries in all tables referencing the post

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

## Change Status

- [x] Complete, tested, ready to review and merge
- [ ] Complete, but not tested (may need new tests)
- [ ] Incomplete/work-in-progress, PR is for discussion/feedback

# How Has This Been Tested?

- [x] Hit the `/posts/:id` endpoint for a post that has favorites/reviews/comments on Insomnia and check in pgAdmin afterwards that the favorites/reviews/comments

# Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] My code has been reviewed by at least one peer
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] There are no merge conflicts
