### PR TITLE
Fixes seeds, adds data to /posts, /posts/:id, & /posts/:id/reviews GETs

### DIFF
--- a/API/posts/posts-model.js
+++ b/API/posts/posts-model.js
@@ -63,7 +63,7 @@ function getAllPosts() {
   })
 }
 
-function getPostById(id) {
+function getPostById(post_id) {
   // Use promise for router error handling
   return new Promise(async (resolve, reject) => {
     let post, steps;
@@ -72,25 +72,31 @@ function getPostById(id) {
       await db.transaction(async trx => {
         // Grab the specified post
         post = await db("posts")
-          .where({ id })
+          .where({ id: post_id })
           .first()
           .returning("*")
           .transacting(trx);
         // Grab the tags for that post
         tags = await db("post_tags as pt")
           .select("pt.*", "t.name")
-          .where({ post_id: id })
+          .where({ post_id })
           .join("tags as t", { "t.id": "pt.tag_id" })
           .transacting(trx);
         // Grab the steps for that post
         steps = await db("post_steps")
-          .where({ post_id: id })
+          .where({ post_id })
           .orderBy("step_num")
           .transacting(trx);
+        reviews = await db("user_post_reviews")
+          .where({post_id});
+        comments = await db("user_post_comments")
+          .where({post_id});
+        favorites = await db("user_favorites")
+          .where({post_id});
       });
       !post
         ? resolve(null) // If post doesn't exist, return null to trigger 404
-        : resolve({ ...post, tags, steps });
+        : resolve({ ...post, tags, steps, reviews, comments, favorites });
     } catch (err) {
       reject(err);
     }

--- a/API/reviews/review-model.js
+++ b/API/reviews/review-model.js
@@ -10,8 +10,10 @@ module.exports = {
 }
 
 function get(id) {
-    return db("user_post_reviews")
-        .where({ post_id: id })
+    return db("user_post_reviews as upr")
+        .select("upr.*", "u.username")
+        .where({ "upr.post_id": id })
+        .join("users as u", {"upr.user_id": "u.id"})
 };
 
 function getByUser(uId) {

--- a/README.md
+++ b/README.md
@@ -133,7 +133,7 @@ Returns an array of objects with top-level details (not including steps):
         "name": STRING
       }],
       "review_count": INTEGER,
-      "review_avg": NUMBER,
+      "review_avg": DECIMAL,
       "comments": INTEGER,
       "favorites": INTEGER
     }

--- a/README.md
+++ b/README.md
@@ -124,7 +124,18 @@ Returns an array of objects with top-level details (not including steps):
       "skills": TEXT,
       "supplies": TEXT,
       "created_by": INTEGER,
-      "created_at": TIMESTAMP WITHOUT TIMEZONE
+      "created_at": TIMESTAMP WITHOUT TIMEZONE,
+      "username": "Sibyl Runolfsdottir",
+      "tags": [{
+        "id": INTEGER,
+        "post_id": INTEGER,
+        "tag_id": INTEGER,
+        "name": STRING
+      }],
+      "review_count": INTEGER,
+      "review_avg": NUMBER,
+      "comments": INTEGER,
+      "favorites": INTEGER
     }
   ]
 }
@@ -163,7 +174,31 @@ Returns an object with the following format:
       "instruction": TEXT,
       "img_url": STRING,
       "vid_url": STRING
-    }
+    },
+    "reviews": [
+      {
+        "id": INTEGER,
+        "user_id": INTEGER,
+        "post_id": INTEGER,
+        "rating": INTEGER,
+        "review": TEXT
+      }
+    ],
+    "comments": [
+      {
+        "id": INTEGER,
+        "user_id": INTEGER,
+        "post_id": INTEGER,
+        "comment": TEXT
+      }
+    ],
+    "favorites": [
+      {
+        "id": INTEGER,
+        "user_id": INTEGER,
+        "post_id": INTEGER
+      },
+    ]
   ]
 }
 ```

--- a/data/seeds/001_users.js
+++ b/data/seeds/001_users.js
@@ -3,12 +3,11 @@ const {genUniqueArr} = require("../helpers.js");
 
 const generateSeeds = () => {
   const numOfUsers = 500;
-  const usernameUnique = genUniqueArr(numOfUsers, faker.internet.userName);
-  const auth_idUnique = genUniqueArr(numOfUsers, faker.random.uuid)
+  const usernameUnique = genUniqueArr(numOfUsers, faker.name.findName);
+  const auth_idUnique = genUniqueArr(numOfUsers, () => `${(Math.floor(Math.random() * 99999999999) + 900000000000)}`);
   let arr = [];
   for (let i = 0; i < numOfUsers; i++) {
     arr.push({
-      //.findName() creates a full name (first and last)
       username: usernameUnique[i],
       auth_id: auth_idUnique[i],
       role: "user"

--- a/data/seeds/002_posts.js
+++ b/data/seeds/002_posts.js
@@ -24,7 +24,7 @@ const httpsImgs = [
 ]
 
 const generatePosts = async () => {
-  const difficulty = ["easy", "intermediate", "advanced", "professional"];
+  const difficulty = ["Very Easy", "Easy", "Moderate", "Hard", "Very Hard"];
   let arr = [];
 
   for (let i = 0; i <= 4; i++) {
@@ -35,7 +35,7 @@ const generatePosts = async () => {
         img_url: httpsImgs[Math.floor(Math.random() * 20)],
         description: faker.lorem.sentences(),
         difficulty: difficulty[Math.floor(Math.random() * difficulty.length)],
-        duration: faker.random.number(),
+        duration: `${Math.ceil(Math.random() * 12)} hours, ${Math.floor(Math.random()*12)*5} minutes`,
         skills: faker.lorem.words(),
         supplies: faker.lorem.words()
       });

--- a/data/seeds/002_posts.js
+++ b/data/seeds/002_posts.js
@@ -31,7 +31,7 @@ const generatePosts = async () => {
     for (let x = 1; x <= 4; x++) {      
       arr.push({
         created_by: x,
-        title: faker.lorem.word(),
+        title: faker.lorem.words(),
         img_url: httpsImgs[Math.floor(Math.random() * 20)],
         description: faker.lorem.sentences(),
         difficulty: difficulty[Math.floor(Math.random() * difficulty.length)],

--- a/data/seeds/002_posts.js
+++ b/data/seeds/002_posts.js
@@ -1,21 +1,38 @@
 const faker = require("faker");
 
+const httpsImgs = [
+  "https://images.unsplash.com/photo-1551118947-62fdc66ad799?ixlib=rb-1.2.1&auto=format&fit=crop&w=1050&q=80",
+  "https://images.unsplash.com/photo-1415383552502-d44cf10dfc7e?ixlib=rb-1.2.1&ixid=eyJhcHBfaWQiOjEyMDd9&auto=format&fit=crop&w=1055&q=80",
+  "https://images.unsplash.com/photo-1517077304055-6e89abbf09b0?ixlib=rb-1.2.1&ixid=eyJhcHBfaWQiOjEyMDd9&auto=format&fit=crop&w=1050&q=80",
+  "https://images.unsplash.com/photo-1517373116369-9bdb8cdc9f62?ixlib=rb-1.2.1&ixid=eyJhcHBfaWQiOjEyMDd9&auto=format&fit=crop&w=1050&q=80",
+  "https://images.unsplash.com/photo-1555664424-778a1e5e1b48?ixlib=rb-1.2.1&auto=format&fit=crop&w=1050&q=80",
+  "https://images.unsplash.com/photo-1556093752-fe3f83f4ae0f?ixlib=rb-1.2.1&ixid=eyJhcHBfaWQiOjEyMDd9&auto=format&fit=crop&w=1048&q=80",
+  "https://images.unsplash.com/photo-1534190239940-9ba8944ea261?ixlib=rb-1.2.1&ixid=eyJhcHBfaWQiOjEyMDd9&auto=format&fit=crop&w=1189&q=80",
+  "https://images.unsplash.com/photo-1503236641037-129adbdfb266?ixlib=rb-1.2.1&auto=format&fit=crop&w=1050&q=80",
+  "https://images.unsplash.com/photo-1496678518751-46244eef08c4?ixlib=rb-1.2.1&auto=format&fit=crop&w=1050&q=80",
+  "https://images.unsplash.com/photo-1491798456967-0f20aa2b60f6?ixlib=rb-1.2.1&ixid=eyJhcHBfaWQiOjEyMDd9&auto=format&fit=crop&w=1266&q=80",
+  "https://images.unsplash.com/photo-1472517990513-4f22ae253bd3?ixlib=rb-1.2.1&ixid=eyJhcHBfaWQiOjEyMDd9&auto=format&fit=crop&w=1053&q=80",
+  "https://images.unsplash.com/photo-1458829549177-e9a8f3db5b14?ixlib=rb-1.2.1&ixid=eyJhcHBfaWQiOjEyMDd9&auto=format&fit=crop&w=1050&q=80",
+  "https://images.unsplash.com/photo-1494831906219-7efab78108d9?ixlib=rb-1.2.1&ixid=eyJhcHBfaWQiOjEyMDd9&auto=format&fit=crop&w=1266&q=80",
+  "https://images.unsplash.com/photo-1475174767135-6d48cae73003?ixlib=rb-1.2.1&ixid=eyJhcHBfaWQiOjEyMDd9&auto=format&fit=crop&w=1050&q=80",
+  "https://images.unsplash.com/photo-1446611720526-39d16597055c?ixlib=rb-1.2.1&ixid=eyJhcHBfaWQiOjEyMDd9&auto=format&fit=crop&w=1050&q=80",
+  "https://images.unsplash.com/photo-1475578749612-705fc64d0574?ixlib=rb-1.2.1&ixid=eyJhcHBfaWQiOjEyMDd9&auto=format&fit=crop&w=1050&q=80",
+  "https://images.unsplash.com/photo-1505798577917-a65157d3320a?ixlib=rb-1.2.1&auto=format&fit=crop&w=1050&q=80",
+  "https://images.unsplash.com/photo-1536236155319-1edab471917c?ixlib=rb-1.2.1&ixid=eyJhcHBfaWQiOjEyMDd9&auto=format&fit=crop&w=1051&q=80",
+  "https://images.unsplash.com/photo-1540103711724-ebf833bde8d1?ixlib=rb-1.2.1&ixid=eyJhcHBfaWQiOjEyMDd9&auto=format&fit=crop&w=1055&q=80",
+  "https://images.unsplash.com/photo-1522065893269-6fd20f6d7438?ixlib=rb-1.2.1&auto=format&fit=crop&w=1050&q=80"
+]
+
 const generatePosts = async () => {
   const difficulty = ["easy", "intermediate", "advanced", "professional"];
   let arr = [];
 
   for (let i = 0; i <= 4; i++) {
-    for (let x = 1; x <= 4; x++) {
-      // Force protocol to https
-      let img_url = faker.image.image();
-      if(img_url.startsWith("http:")) {
-        img_url = img_url.replace("http:", "https:")
-      }
-      
+    for (let x = 1; x <= 4; x++) {      
       arr.push({
         created_by: x,
         title: faker.lorem.word(),
-        img_url,
+        img_url: httpsImgs[Math.floor(Math.random() * 20)],
         description: faker.lorem.sentences(),
         difficulty: difficulty[Math.floor(Math.random() * difficulty.length)],
         duration: faker.random.number(),

--- a/data/seeds/003_post_steps.js
+++ b/data/seeds/003_post_steps.js
@@ -1,5 +1,28 @@
 const faker = require("faker");
 
+const httpsImgs = [
+  "https://images.unsplash.com/photo-1551118947-62fdc66ad799?ixlib=rb-1.2.1&auto=format&fit=crop&w=1050&q=80",
+  "https://images.unsplash.com/photo-1415383552502-d44cf10dfc7e?ixlib=rb-1.2.1&ixid=eyJhcHBfaWQiOjEyMDd9&auto=format&fit=crop&w=1055&q=80",
+  "https://images.unsplash.com/photo-1517077304055-6e89abbf09b0?ixlib=rb-1.2.1&ixid=eyJhcHBfaWQiOjEyMDd9&auto=format&fit=crop&w=1050&q=80",
+  "https://images.unsplash.com/photo-1517373116369-9bdb8cdc9f62?ixlib=rb-1.2.1&ixid=eyJhcHBfaWQiOjEyMDd9&auto=format&fit=crop&w=1050&q=80",
+  "https://images.unsplash.com/photo-1555664424-778a1e5e1b48?ixlib=rb-1.2.1&auto=format&fit=crop&w=1050&q=80",
+  "https://images.unsplash.com/photo-1556093752-fe3f83f4ae0f?ixlib=rb-1.2.1&ixid=eyJhcHBfaWQiOjEyMDd9&auto=format&fit=crop&w=1048&q=80",
+  "https://images.unsplash.com/photo-1534190239940-9ba8944ea261?ixlib=rb-1.2.1&ixid=eyJhcHBfaWQiOjEyMDd9&auto=format&fit=crop&w=1189&q=80",
+  "https://images.unsplash.com/photo-1503236641037-129adbdfb266?ixlib=rb-1.2.1&auto=format&fit=crop&w=1050&q=80",
+  "https://images.unsplash.com/photo-1496678518751-46244eef08c4?ixlib=rb-1.2.1&auto=format&fit=crop&w=1050&q=80",
+  "https://images.unsplash.com/photo-1491798456967-0f20aa2b60f6?ixlib=rb-1.2.1&ixid=eyJhcHBfaWQiOjEyMDd9&auto=format&fit=crop&w=1266&q=80",
+  "https://images.unsplash.com/photo-1472517990513-4f22ae253bd3?ixlib=rb-1.2.1&ixid=eyJhcHBfaWQiOjEyMDd9&auto=format&fit=crop&w=1053&q=80",
+  "https://images.unsplash.com/photo-1458829549177-e9a8f3db5b14?ixlib=rb-1.2.1&ixid=eyJhcHBfaWQiOjEyMDd9&auto=format&fit=crop&w=1050&q=80",
+  "https://images.unsplash.com/photo-1494831906219-7efab78108d9?ixlib=rb-1.2.1&ixid=eyJhcHBfaWQiOjEyMDd9&auto=format&fit=crop&w=1266&q=80",
+  "https://images.unsplash.com/photo-1475174767135-6d48cae73003?ixlib=rb-1.2.1&ixid=eyJhcHBfaWQiOjEyMDd9&auto=format&fit=crop&w=1050&q=80",
+  "https://images.unsplash.com/photo-1446611720526-39d16597055c?ixlib=rb-1.2.1&ixid=eyJhcHBfaWQiOjEyMDd9&auto=format&fit=crop&w=1050&q=80",
+  "https://images.unsplash.com/photo-1475578749612-705fc64d0574?ixlib=rb-1.2.1&ixid=eyJhcHBfaWQiOjEyMDd9&auto=format&fit=crop&w=1050&q=80",
+  "https://images.unsplash.com/photo-1505798577917-a65157d3320a?ixlib=rb-1.2.1&auto=format&fit=crop&w=1050&q=80",
+  "https://images.unsplash.com/photo-1536236155319-1edab471917c?ixlib=rb-1.2.1&ixid=eyJhcHBfaWQiOjEyMDd9&auto=format&fit=crop&w=1051&q=80",
+  "https://images.unsplash.com/photo-1540103711724-ebf833bde8d1?ixlib=rb-1.2.1&ixid=eyJhcHBfaWQiOjEyMDd9&auto=format&fit=crop&w=1055&q=80",
+  "https://images.unsplash.com/photo-1522065893269-6fd20f6d7438?ixlib=rb-1.2.1&auto=format&fit=crop&w=1050&q=80"
+]
+
 const generateSeeds = () => {
   const numOfPosts = 20;
   let arr = [];
@@ -16,7 +39,7 @@ const generateSeeds = () => {
         step_num: j,
         title: faker.lorem.sentence(),
         instruction: faker.lorem.paragraph(),
-        img_url
+        img_url: httpsImgs[Math.floor(Math.random() * 20)]
       });
     }
   }

--- a/data/seeds/003_post_steps.js
+++ b/data/seeds/003_post_steps.js
@@ -28,12 +28,6 @@ const generateSeeds = () => {
   let arr = [];
   for (let i = 1; i < numOfPosts + 1; i++) {
     for (let j = 1; j < 4; j++) {
-      // Force protocol to https
-      let img_url = faker.image.image();
-      if(img_url.startsWith("http:")) {
-        img_url = img_url.replace("http:", "https:")
-      }
-
       arr.push({
         post_id: i,
         step_num: j,


### PR DESCRIPTION
# Description

- Add tags, reviews, comments, & favorites data to /posts GET
- Add reviews, comments, & favorites data to /posts/:id GET
- Add username data to /posts/:id/reviews GET
- Fix https issues w/ seeded image URLs
- Make users data more similar to data received from Google

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

## Change Status

- [x] Complete, tested, ready to review and merge
- [ ] Complete, but not tested (may need new tests)
- [ ] Incomplete/work-in-progress, PR is for discussion/feedback

# How Has This Been Tested?

- [x] `yarn knex seed:run` to re-seed the DB and checked in pgAdmin to see if `img_url`s for `posts` & `post_steps` tables use HTTPS and if `users` entries have a 12-digit auth_id and a display name
- [x] Hit `/posts` & `/posts/:id` GET endpoints in Insomnia to see if tags, reviews, comments, & favorites data is there
- [x] Hit `/posts/:id/reviews` GET endpoint in Insomnia to see if username data is there for each review

# Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My code has been reviewed by at least one peer
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] There are no merge conflicts
